### PR TITLE
feat(special_chars_title): Handle special chars in title by ignoring them

### DIFF
--- a/services/wikipedia_service.js
+++ b/services/wikipedia_service.js
@@ -100,7 +100,12 @@ class WikipediaService {
     }
 
     return pageTitles.filter((title) => {
-      let titleWords = title.split(" ");
+      // Preprocess the title: remove special characters and split into words
+      let titleWords = title
+        .replace(/[()]/g, "") // Remove parentheses
+        .replace(/-/g, " ") // Replace dash with spaces
+        .split(" "); // Split into words
+
       // Check if the title has the expected number of words
       if (titleWords.length !== titleFilter.expectedTitleSize) {
         return false;


### PR DESCRIPTION
This pull request refactors the `PageWrapper` class in `services/page_wrapper.js` and updates the `WikipediaService` class in `services/wikipedia_service.js` to simplify handling of special characters and improve readability. The changes focus on removing redundant methods, streamlining logic, and enhancing preprocessing of text.

### Refactoring in `PageWrapper` (`services/page_wrapper.js`):

* **Regex Update**: Extended the `ignoreRegex` to include the forward slash (`/`) for ignoring additional special characters.
* **Simplified Dash and Parenthesis Handling**: Replaced the `isDashWord` method with `isDashOrParenthesis`, consolidating the logic for ignoring dashes and parentheses, and removed the complex `processDashWordInTitle` method. 
* **Optimized Word Size Calculation**: Removed the `getNonFoundWordSize` method and directly calculated the word size using `offsetWidth / this.titleLetterSize` in `processNonFoundWordInTitle`.

### Enhancements in `WikipediaService` (`services/wikipedia_service.js`):

* **Title Preprocessing**: Added preprocessing logic to remove parentheses, replace dashes with spaces, and split titles into words for better filtering.